### PR TITLE
Fixed DateTime parsing in non-US locale

### DIFF
--- a/ssas_api.py
+++ b/ssas_api.py
@@ -174,6 +174,7 @@ def _parse_DAX_result(table: "DataTable") -> pd.DataFrame:
         for dtt in dt_types:
             # if all nulls, then pd.to_datetime will fail
             if not df.loc[:, dtt].isna().all():
+                # https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable
                 ser = df.loc[:, dtt].map(lambda x: x.ToString('s'))
                 df.loc[:, dtt] = pd.to_datetime(ser)
 

--- a/ssas_api.py
+++ b/ssas_api.py
@@ -174,7 +174,7 @@ def _parse_DAX_result(table: "DataTable") -> pd.DataFrame:
         for dtt in dt_types:
             # if all nulls, then pd.to_datetime will fail
             if not df.loc[:, dtt].isna().all():
-                ser = df.loc[:, dtt].map(lambda x: x.ToString())
+                ser = df.loc[:, dtt].map(lambda x: x.ToString('s'))
                 df.loc[:, dtt] = pd.to_datetime(ser)
 
     # convert other types


### PR DESCRIPTION
The fix consists in forcing the formatted datetime to reflect the ISO 8601 format. This should avoid switching between days and months in locale that use DD/MM/YYYY formats

fixes #8 