### PR TITLE
Fix Load vs LoadFrom

### DIFF
--- a/ssas_api.py
+++ b/ssas_api.py
@@ -174,7 +174,7 @@ def _parse_DAX_result(table: "DataTable") -> pd.DataFrame:
         for dtt in dt_types:
             # if all nulls, then pd.to_datetime will fail
             if not df.loc[:, dtt].isna().all():
-                ser = df.loc[:, dtt].map(lambda x: x.ToString())
+                ser = df.loc[:, dtt].map(lambda x: x.ToString('s'))
                 df.loc[:, dtt] = pd.to_datetime(ser)
 
     # convert other types


### PR DESCRIPTION
Please verify if I'm doing it correctly, but pre-fix I couldn't manage to load the DLLs installed from nuget.

If I've undestood it correctly `clr.AddReference` uses `Assembly.Load` instead of `Assembly.LoadFrom`. The former expects an assembly definition, while the latter expects a path.

Please let me know if you find this correct.